### PR TITLE
matplotlib 2.1.0 extra workaround

### DIFF
--- a/package/debian8/rules
+++ b/package/debian8/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=silx
+export SPECFILE_USE_GNU_SOURCE=1
 
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/package/debian9/rules
+++ b/package/debian9/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=silx
+export SPECFILE_USE_GNU_SOURCE=1
 
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "02/10/2017"
+__date__ = "16/10/2017"
 __license__ = "MIT"
 
 
@@ -720,6 +720,7 @@ def get_project_configuration(dry_run):
             'gui/icons/*/*.png',
             'opencl/*.cl',
             'opencl/sift/*.cl',
+            'opencl/codec/*.cl',
             'gui/colormaps/*.npy'],
     }
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -602,10 +602,32 @@ class BackendMatplotlib(BackendBase.BackendBase):
     # Graph axes
 
     def setXAxisLogarithmic(self, flag):
+        # Workaround for matplotlib 2.1.0 when one tries to set an axis
+        # to log scale with both limits <= 0
+        # In this case a draw with positive limits is needed first
+        if flag and matplotlib.__version__ >= '2.1.0':
+            xlim = self.ax.get_xlim()
+            if xlim[0] <= 0 and xlim[1] <= 0:
+                self.ax.set_xlim(1, 10)
+                self.draw()
+
         self.ax2.set_xscale('log' if flag else 'linear')
         self.ax.set_xscale('log' if flag else 'linear')
 
     def setYAxisLogarithmic(self, flag):
+        # Workaround for matplotlib 2.1.0 when one tries to set an axis
+        # to log scale with both limits <= 0
+        # In this case a draw with positive limits is needed first
+        if flag and matplotlib.__version__ >= '2.1.0':
+            redraw = False
+            for axis in (self.ax, self.ax2):
+                ylim = axis.get_ylim()
+                if ylim[0] <= 0 and ylim[1] <= 0:
+                    axis.set_ylim(1, 10)
+                    redraw = True
+            if redraw:
+                self.draw()
+
         self.ax2.set_yscale('log' if flag else 'linear')
         self.ax.set_yscale('log' if flag else 'linear')
 

--- a/silx/gui/plot/items/axis.py
+++ b/silx/gui/plot/items/axis.py
@@ -220,7 +220,7 @@ class Axis(qt.QObject):
         for item in self._plot._getItems(withhidden=True):
             item._updated()
         self._plot._invalidateDataRange()
-        self._plot.resetZoom()
+        self._plot._forceResetZoom()
 
         self.sigScaleChanged.emit(self._scale)
         if emitLog:

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -31,6 +31,7 @@ __date__ = "06/03/2017"
 
 
 import logging
+import numpy
 
 from .. import Colors
 from .core import (Points, LabelsMixIn, ColorMixIn, YAxisMixIn,
@@ -75,7 +76,7 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
         xFiltered, yFiltered, xerror, yerror = self.getData(
             copy=False, displayed=True)
 
-        if len(xFiltered) == 0:
+        if len(xFiltered) == 0 or not numpy.any(numpy.isfinite(xFiltered)):
             return None  # No data to display, do not add renderer to backend
 
         return backend.addCurve(xFiltered, yFiltered, self.getLegend(),

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -98,8 +98,7 @@ class ByteOffset(OpenclProcessing):
         neutral = "(int2)(0,0)"
         output_statement = "value[i] = item.s0; index[i+1] = item.s1;"
         # if self.device.type == "GPU":
-        
-        if 
+
         if self.block_size >= 64:
             knl = GenericScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
         else:  # MacOS on CPU

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -125,9 +125,8 @@ class ByteOffset(OpenclProcessing):
             len_raw = numpy.int32(len(raw))
             if len_raw > self.padded_raw_size:
                 wg = self.block_size
-                raw_size = int(len_raw)
-                self.raw_size = raw_size
-                self.padded_raw_size = (raw_size + wg - 1) & ~(wg - 1)
+                self.raw_size = int(len(raw))
+                self.padded_raw_size = (self.raw_size + wg - 1) & ~(wg - 1)
                 logger.info("increase raw buffer size to %s", self.padded_raw_size)
                 buffers = {
                            "raw": pyopencl.array.empty(self.queue, self.padded_raw_size, dtype=numpy.int8),
@@ -169,7 +168,7 @@ class ByteOffset(OpenclProcessing):
                                         is_blocking=False)
             events.append(EventDescription("copy counter D -> H", evt))
             evt.wait()
-            nbexc = nb_exceptions[0]
+            nbexc = int(nb_exceptions[0])
             if nbexc == 0:
                 logger.info("nbexc %i", nbexc)
             else:

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Sift implementation in Python + OpenCL
+#             https://github.com/silx-kit/silx
+#
+#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Contains classes CBF byte offset decompression
+"""
+
+from __future__ import division, print_function, with_statement
+
+__authors__ = ["Jérôme Kieffer"]
+__contact__ = "jerome.kieffer@esrf.eu"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "13/10/2017"
+__status__ = "production"
+
+import os
+import gc
+import numpy
+from ..common import ocl, pyopencl, kernel_workgroup_size
+from ..processing import BufferDescription, EventDescription, OpenclProcessing
+
+import logging
+logger = logging.getLogger(__name__)
+if not pyopencl:
+    logger.warning("No PyOpenCL, no byte-offset, please see fabio")
+
+
+class ByteOffsetDecompressor(OpenclProcessing):
+    "Perform the byte offset decompression on the GPU"
+    def __init__(self, raw_size, dec_size=None, ctx=None, devicetype="all",
+                 platformid=None, deviceid=None,
+                 block_size=None, profile=False):
+        """Constructor of the Byte Offset decompressor 
+        
+        """
+
+        OpenclProcessing.__init__(ctx=ctx, devicetype=devicetype,
+                                  platformid=platformid, deviceid=deviceid,
+                                  block_size=block_size, profile=profile)
+        self.raw_size = int(raw_size)
+        if not dec_size:
+            dec_size = self.raw_size
+        self.dec_size = int(dec_size)
+
+        buffers = [
+                    BufferDescription("raw", self.raw_size, numpy.int8, None),
+                    BufferDescription("mask", self.raw_size, numpy.int32, None),
+                    BufferDescription("exceptions", self.raw_size, numpy.int32, None),
+                    BufferDescription("counter", 1, numpy.int32, None),
+                    BufferDescription("data_simple", self.raw_size, numpy.int32, None),
+                    BufferDescription("data_except", self.raw_size, numpy.int32, None),
+                    BufferDescription("delta", self.raw_size, numpy.int32, None),
+                    BufferDescription("exceptions", self.raw_size, numpy.int32, None),
+                    BufferDescription("data_float", self.dec_size, numpy.float32, None),
+                   ]
+        self.allocate_buffers(buffers, as_array=True)
+        self.compile_kernels(os.path.join("codec", "byte_offset"))
+
+    def dec(self, raw, as_float=True, out=None):
+        """This function actually performs the decompression by calling the kernels
+        """
+        events = []
+        with self.sem:
+            evt = self.kernels.fill_char_mem(self.queue, (self.raw_size,), None,
+                                             self.cl_mem["raw"].data,
+                                             numpy.int32(self.raw_size),
+                                             numpy.int32(0), numpy.int32(len(raw)))
+            events.append(EventDescription("memset raw buffer", evt))
+            evt = pyopencl.enqueue_copy(self.queue, self.cl_mem["raw"].data,
+                                        raw,
+                                        is_blocking=False)
+            events.append(EventDescription("copy raw H -> D", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (self.raw_size,), None,
+                                            self.cl_mem["mask"].data,
+                                            numpy.int32(self.raw_size),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset mask buffer", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (self.raw_size,), None,
+                                            self.cl_mem["data_simple"].data,
+                                            numpy.int32(self.raw_size),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset data_simple", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (self.raw_size,), None,
+                                            self.cl_mem["data_except"].data,
+                                            numpy.int32(self.raw_size),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset data_except", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (self.raw_size,), None,
+                                            self.cl_mem["delta"].data,
+                                            numpy.int32(self.raw_size),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset delta", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (1,), None,
+                                            self.cl_mem["counter"].data,
+                                            numpy.int32(1),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset counter", evt))
+            evt = self.kernels.fill_int_mem(self.queue, (self.raw_size,), None,
+                                            self.cl_mem["exceptions"].data,
+                                            numpy.int32(self.raw_size),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset exceptions", evt))
+
+            evt = self.kernels.mark_exceptions(self.queue, (self.raw_size,), None,
+                                               self.cl_mem["raw"].data,
+                                               numpy.int32(self.raw_size),
+                                               self.cl_mem["mask"].data,
+                                               self.cl_mem["counter"].data,
+                                               self.cl_mem["exceptions"].data)
+            events.append(EventDescription("mark exceptions", evt))
+            nb_exceptions = numpy.empty(1, dtype=numpy.int32)
+            evt = pyopencl.enqueue_copy(self.queue, nb_exceptions, self.cl_mem["counter"].data,
+                                        is_blocking=False)
+            events.append(EventDescription("copy counter D -> H", evt))
+            evt.wait()
+            nbexc = nb_exceptions[0]
+            evt = self.kernels.treat_exceptions(self.queue, (nbexc,), (1,),
+                                                self.cl_mem["raw"].data,
+                                                numpy.int32(self.raw_size),
+                                                self.cl_mem["mask"].data,
+                                                self.cl_mem["exceptions"].data,
+                                                self.cl_mem["data_except"].data,
+                                                self.cl_mem["delta"].data
+                                                )
+            events.append(EventDescription("treat exceptions", evt))
+            evt = self.kernels.calc_size(self.queue, (self.raw_size,), None,
+                                         numpy.int32(self.raw_size),
+                                         self.cl_mem["mask"].data,
+                                         self.cl_mem["delta"].data)
+            events.append(EventDescription("calc size", evt))
+            ary1_d, count_d, e = pyopencl.algorithm.copy_if(delta_d, predicate="ary[i]>0", queue=queue)
+            events.append(e)
+            size_out = count_d.get()
+            e, ary2_d = pyopencl.array.cumsum(ary1_d, numpy.int32, queue, return_event=True)
+            events.append(e)
+
+            e = copy_values(queue, (size,) , None,
+                            raw_d.data, numpy.int32(size), numpy.int32(count.get()),
+                            data1_d.data, data2_d.data,
+                            ary2_d.data, delta_d.data)
+            events.append(e)
+            e, ary3_d = pyopencl.array.cumsum(data1_d, numpy.int32, queue, return_event=True)
+            events.append(e)
+        return ary3_d

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -184,7 +184,7 @@ class ByteOffset(OpenclProcessing):
             evt = self.kernels.scan(self.cl_mem["values"],
                                     self.cl_mem["mask"],
                                     queue=self.queue,
-                                    size=len_raw,
+                                    size=int(len_raw),
                                     wait_for=(evt,))
             events.append(EventDescription("double scan", evt))
             if out is not None:

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -37,7 +37,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "17/10/2017"
+__date__ = "19/10/2017"
 __status__ = "production"
 
 import os
@@ -65,73 +65,84 @@ class ByteOffset(OpenclProcessing):
 
         OpenclProcessing.__init__(self, ctx=ctx, devicetype=devicetype,
                                   platformid=platformid, deviceid=deviceid,
-                                  block_size=block_size, profile=profile)
-        self.raw_size = int(raw_size)
-        self.dec_size = int(dec_size)
-
+                                  block_size=min(block_size, 128), profile=profile)
+        wg = self.block_size
+        self.raw_size = numpy.int32(raw_size)
+        self.dec_size = numpy.int32(dec_size)
+        self.padded_raw_size = (self.raw_size + wg - 1) & ~(wg - 1)
+        self.padded_dec_size = (self.dec_size + wg - 1) & ~(wg - 1)
         buffers = [
                     BufferDescription("raw", self.raw_size, numpy.int8, None),
                     BufferDescription("mask", self.raw_size, numpy.int32, None),
+                    BufferDescription("values", self.raw_size, numpy.int32, None),
                     BufferDescription("exceptions", self.raw_size, numpy.int32, None),
                     BufferDescription("counter", 1, numpy.int32, None),
-                    BufferDescription("data_non_compact", self.raw_size, numpy.int32, None),
                     BufferDescription("data_float", self.dec_size, numpy.float32, None),
                     BufferDescription("data_int", self.dec_size, numpy.int32, None),
                    ]
         self.allocate_buffers(buffers, use_array=True)
         self.compile_kernels([os.path.join("codec", "byte_offset")])
+        self.kernels.__setattr__("scan", self._init_double_scan)
+
+    def _init_double_scan(self):
+        "generates a double scan on indexes and values in one operation"
+        int2 = pyopencl.tools.get_or_register_dtype("int2")
+        input_expr = "mask[i]?(int2)(0, 0):(int2)(value[i], 1)"
+        scan_expr = "a+b"
+        neutral = "(int2)(0,0)"
+        arguments = "__global int *value", "__global int *index"
+        output_statement = "value[i] = item.s0; index[i+1] = item.s1;"
+        if self.block_size >= 64:
+            knl = pyopencl.algorithm.GenericScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
+        else:  # MacOS on CPU
+            knl = pyopencl.scan.GenericDebugScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
+        return knl
 
     def dec(self, raw, as_float=False, out=None):
         """This function actually performs the decompression by calling the kernels
         """
         events = []
         with self.sem:
-            wg = min(128, self.device.max_work_group_size)  # try to access data by 128 bytes
             len_raw = numpy.int32(len(raw))
-            size = (len(raw) + wg - 1) & ~(wg - 1)
-
-            if len(raw) > self.raw_size:
+            if len_raw > self.raw_size:
                 logger.info("increase raw buffer size to %s", len(raw))
                 raw_size = len(raw)
                 buffers = {
                            "raw": pyopencl.array.empty(self.queue, raw_size, dtype=numpy.int8),
                            "mask": pyopencl.array.empty(self.queue, raw_size, dtype=numpy.int32),
                            "exceptions": pyopencl.array.empty(self.queue, raw_size, dtype=numpy.int32),
-                           "data_non_compact": pyopencl.array.empty(self.queue, raw_size, dtype=numpy.int32),
-                           }
+                           "values": pyopencl.array.empty(self.queue, raw_size, dtype=numpy.int32),
+                          }
                 self.raw_size = raw_size
+                wg = self.block_size
+                self.padded_raw_size = (raw_size + wg - 1) & ~(wg - 1)
                 self.cl_mem.update(buffers)
-            if self.raw_size > len(raw):
-                evt = self.kernels.fill_char_mem(self.queue, (size,), (wg,),
-                                                 self.cl_mem["raw"].data,
-                                                 numpy.int32(self.raw_size),
-                                                 numpy.int8(0),
-                                                 len_raw)
-                events.append(EventDescription("memset raw buffer", evt))
+
             evt = pyopencl.enqueue_copy(self.queue, self.cl_mem["raw"].data,
                                         raw,
                                         is_blocking=False)
             events.append(EventDescription("copy raw H -> D", evt))
-            evt = self.kernels.fill_int_mem(self.queue, (size,), (wg,),
+
+            evt = self.kernels.fill_int_mem(self.queue, (self.padded_raw_size,), (wg,),
                                             self.cl_mem["mask"].data,
-                                            len_raw,
-                                            numpy.int32(0), numpy.int32(0))
-            events.append(EventDescription("memset mask buffer", evt))
-            evt = self.kernels.fill_int_mem(self.queue, (size,), (wg,),
-                                            self.cl_mem["data_non_compact"].data,
-                                            len_raw,
-                                            numpy.int32(0), numpy.int32(0))
-            events.append(EventDescription("memset data_non_compact", evt))
-            evt = self.kernels.fill_int_mem(self.queue, (1,), None,
+                                            self.raw_size,
+                                            numpy.int32(0),
+                                            numpy.int32(0))
+            events.append(EventDescription("memset mask", evt))
+
+            evt = self.kernels.fill_int_mem(self.queue, (1,), (1,),
                                             self.cl_mem["counter"].data,
                                             numpy.int32(1),
-                                            numpy.int32(0), numpy.int32(0))
+                                            numpy.int32(0),
+                                            numpy.int32(0))
             events.append(EventDescription("memset counter", evt))
 
-            evt = self.kernels.mark_exceptions(self.queue, (size,), (wg,),
+            evt = self.kernels.mark_exceptions(self.queue, (self.padded_raw_size,), (wg,),
                                                self.cl_mem["raw"].data,
                                                len_raw,
+                                               self.raw_size,
                                                self.cl_mem["mask"].data,
+                                               self.cl_mem["values"].data,
                                                self.cl_mem["counter"].data,
                                                self.cl_mem["exceptions"].data)
             events.append(EventDescription("mark exceptions", evt))
@@ -146,31 +157,31 @@ class ByteOffset(OpenclProcessing):
                                                 len_raw,
                                                 self.cl_mem["mask"].data,
                                                 self.cl_mem["exceptions"].data,
-                                                self.cl_mem["data_non_compact"].data
+                                                self.cl_mem["values"].data
                                                 )
             events.append(EventDescription("treat_exceptions", evt))
-            evt = self.kernels.treat_simple(self.queue, (size,), (wg,),
-                                            self.cl_mem["raw"].data,
-                                            len_raw,
-                                            self.cl_mem["mask"].data,
-                                            self.cl_mem["data_non_compact"].data)
-            events.append(EventDescription("treat_simple", evt))
-
-            evt, cumsummed_d = pyopencl.array.cumsum(self.cl_mem["data_non_compact"],
-                                                     numpy.int32, self.queue,
-                                                     return_event=True)
-
-            events.append(EventDescription("cumsum", evt))
-
-            indexes_d, count_d, evt = pyopencl.algorithm.copy_if(self.cl_mem["mask"],
-                                                                 predicate="ary[i]>=0",
-                                                                 queue=self.queue,
-                                                                 )
-            events.append(EventDescription("copy_if", evt))
-            size_out = count_d.get()  # synchro here
-            if size_out != self.dec_size:
-                logger.info("decompressed size = %i, expected %i", size_out, self.dec_size)
-                size_out = min(size_out, self.dec_size)
+#             evt = self.kernels.treat_simple(self.queue, (self.padded_raw_size,), (wg,),
+#                                             self.cl_mem["raw"].data,
+#                                             len_raw,
+#                                             self.cl_mem["mask"].data,
+#                                             self.cl_mem["values"].data)
+#             events.append(EventDescription("treat_simple", evt))
+#
+#             evt, cumsummed_d = pyopencl.array.cumsum(self.cl_mem["data_non_compact"],
+#                                                      numpy.int32, self.queue,
+#                                                      return_event=True)
+#
+#             events.append(EventDescription("cumsum", evt))
+#
+#             indexes_d, count_d, evt = pyopencl.algorithm.copy_if(self.cl_mem["mask"],
+#                                                                  predicate="ary[i]>=0",
+#                                                                  queue=self.queue,
+#                                                                  )
+#             events.append(EventDescription("copy_if", evt))
+#             size_out = count_d.get()  # synchro here
+#             if size_out != self.dec_size:
+#                 logger.info("decompressed size = %i, expected %i", size_out, self.dec_size)
+#                 size_out = min(size_out, self.dec_size)
             if out is not None:
                 if out.dtype == numpy.float32:
                     copy_results = self.kernels.copy_result_float
@@ -183,9 +194,9 @@ class ByteOffset(OpenclProcessing):
                 else:
                     out = self.cl_mem["data_int"]
                     copy_results = self.kernels.copy_result_int
-            if out.size != size_out:
-                print("out size: %s expected: %s" % (out.size, size_out))
-            evt = copy_results(self.queue, ((size_out + wg - 1) & ~(wg - 1),), (wg,),
+#             if out.size != size_out:
+#                 print("out size: %s expected: %s" % (out.size, size_out))
+            evt = copy_results(self.queue, self.padded_dec_size, (wg,),
                                cumsummed_d.data,
                                indexes_d.data,
                                numpy.int32(size_out),

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -62,9 +62,11 @@ class ByteOffset(OpenclProcessing):
     def __init__(self, raw_size, dec_size, ctx=None, devicetype="all",
                  platformid=None, deviceid=None,
                  block_size=None, profile=False):
-        """Constructor of the Byte Offset decompressor 
-        
-        :param raw_size: size of the raw stream, can be (slightly) larger than the array 
+        """Constructor of the Byte Offset decompressor.
+
+        See :class:`OpenclProcessing` for optional arguments description.
+
+        :param raw_size: size of the raw stream, can be (slightly) larger than the array
         :param dec_size: size of the output array (mandatory)
         """
 
@@ -117,8 +119,15 @@ class ByteOffset(OpenclProcessing):
                                          output_statement=output_statement)
         return knl
 
-    def dec(self, raw, as_float=False, out=None):
+    def decode(self, raw, as_float=False, out=None):
         """This function actually performs the decompression by calling the kernels
+
+        :param numpy.ndarray raw: The compressed data as a 1D numpy array of char.
+        :param bool as_float: True to decompress as float32,
+                              False (default) to decompress as int32
+        :param pyopencl.array out: pyopencl array in which to place the result.
+        :return: The decompressed image as an pyopencl array.
+        :rtype: pyopencl.array
         """
         events = []
         with self.sem:
@@ -211,4 +220,4 @@ class ByteOffset(OpenclProcessing):
                 self.events += events
         return out
 
-    __call__ = dec
+    __call__ = decode

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -37,7 +37,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "20/10/2017"
+__date__ = "24/10/2017"
 __status__ = "production"
 
 import os
@@ -47,7 +47,11 @@ from ..processing import BufferDescription, EventDescription, OpenclProcessing
 import logging
 logger = logging.getLogger(__name__)
 if pyopencl:
-    import pyopencl.algorithm
+    import pyopencl.version
+    if pyopencl.version.VERSION < (2016, 0):
+        from pyopencl.scan import GenericScanKernel, GenericDebugScanKernel
+    else:
+        from pyopencl.algorithm import GenericScanKernel, GenericDebugScanKernel
 else:
     logger.warning("No PyOpenCL, no byte-offset, please see fabio")
 
@@ -94,10 +98,12 @@ class ByteOffset(OpenclProcessing):
         neutral = "(int2)(0,0)"
         output_statement = "value[i] = item.s0; index[i+1] = item.s1;"
         # if self.device.type == "GPU":
+        
+        if 
         if self.block_size >= 64:
-            knl = pyopencl.algorithm.GenericScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
+            knl = GenericScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
         else:  # MacOS on CPU
-            knl = pyopencl.scan.GenericDebugScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
+            knl = GenericDebugScanKernel(self.ctx, int2, arguments, input_expr, scan_expr, neutral, output_statement)
         return knl
 
     def dec(self, raw, as_float=False, out=None):

--- a/silx/opencl/codec/setup.py
+++ b/silx/opencl/codec/setup.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+#
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from __future__ import division
+
+__contact__ = "jerome.kieffer@esrf.eu"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__authors__ = ["J. Kieffer"]
+__date__ = "13/10/2017"
+
+from numpy.distutils.misc_util import Configuration
+
+
+def configuration(parent_package='', top_path=None):
+    config = Configuration('codec', parent_package, top_path)
+    config.add_subpackage('test')
+    return config
+
+
+if __name__ == "__main__":
+    from numpy.distutils.core import setup
+    setup(configuration=configuration)

--- a/silx/opencl/codec/test/__init__.py
+++ b/silx/opencl/codec/test/__init__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+#    Project: silx
+#             https://github.com/silx-kit/silx
+#
+#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+__authors__ = ["J. Kieffer"]
+__license__ = "MIT"
+__date__ = "13/10/2017"
+
+import unittest
+from . import test_byte_offset
+
+
+def suite():
+    testSuite = unittest.TestSuite()
+    testSuite.addTest(test_byte_offset.suite())
+
+    return testSuite

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -36,18 +36,92 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "2013 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "13/10/2017"
+__date__ = "16/10/2017"
 
 import os
 import time
 import logging
 import numpy
-
+from silx.opencl import ocl
 import unittest
+logger = logging.getLogger(__name__)
+
+
+@unittest.skipUnless(ocl, "PyOpenCl is missing")
+class TestAlgebra(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestAlgebra, cls).setUpClass()
+        if ocl:
+            cls.ctx = ocl.create_context()
+            if logger.getEffectiveLevel() <= logging.INFO:
+                cls.PROFILE = True
+                cls.queue = pyopencl.CommandQueue(cls.ctx, properties=pyopencl.command_queue_properties.PROFILING_ENABLE)
+            else:
+                cls.PROFILE = False
+                cls.queue = pyopencl.CommandQueue(cls.ctx)
+            device = cls.ctx.devices[0]
+            device_id = device.platform.get_devices().index(device)
+            platform_id = pyopencl.get_platforms().index(device.platform)
+            cls.maxwg = ocl.platforms[platform_id].devices[device_id].max_work_group_size
+#             logger.warning("max_work_group_size: %s on (%s, %s)", cls.maxwg, platform_id, device_id)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestAlgebra, cls).tearDownClass()
+        cls.ctx = None
+        cls.queue = None
+
+    def setUp(self):
+        kernel_src = get_opencl_code(os.path.join("sift", "algebra.cl"))
+        self.program = pyopencl.Program(self.ctx, kernel_src).build()
+        self.wg = (32, 4)
+        if self.maxwg < self.wg[0] * self.wg[1]:
+            self.wg = (self.maxwg, 1)
+
+    def tearDown(self):
+        self.mat1 = None
+        self.mat2 = None
+        self.program = None
+
+    def test_combine(self):
+        """
+        tests the combine (linear combination) kernel
+        """
+        width = numpy.int32(157)
+        height = numpy.int32(147)
+        coeff1 = numpy.random.rand(1)[0].astype(numpy.float32)
+        coeff2 = numpy.random.rand(1)[0].astype(numpy.float32)
+        mat1 = numpy.random.rand(height, width).astype(numpy.float32)
+        mat2 = numpy.random.rand(height, width).astype(numpy.float32)
+
+        gpu_mat1 = pyopencl.array.to_device(self.queue, mat1)
+        gpu_mat2 = pyopencl.array.to_device(self.queue, mat2)
+        gpu_out = pyopencl.array.empty(self.queue, mat1.shape, dtype=numpy.float32, order="C")
+        shape = calc_size((width, height), self.wg)
+
+        t0 = time.time()
+        try:
+            k1 = self.program.combine(self.queue, shape, None,
+                                      gpu_mat1.data, coeff1, gpu_mat2.data, coeff2,
+                                      gpu_out.data, numpy.int32(0),
+                                      width, height)
+        except pyopencl.LogicError as error:
+            logger.warning("%s in test_combine", error)
+        res = gpu_out.get()
+        t1 = time.time()
+        ref = my_combine(mat1, coeff1, mat2, coeff2)
+        t2 = time.time()
+        delta = abs(ref - res).max()
+        logger.debug("delta=%s" % delta)
+        self.assert_(delta < 1e-4, "delta=%s" % (delta))
+        if self.PROFILE:
+            logger.debug("Global execution time: CPU %.3fms, GPU: %.3fms." % (1000.0 * (t2 - t1), 1000.0 * (t1 - t0)))
+            logger.debug("Linear combination took %.3fms" % (1e-6 * (k1.profile.end - k1.profile.start)))
 
 
 def suite():
     testSuite = unittest.TestSuite()
-#     testSuite.addTest(TestAlgebra("test_combine"))
+     testSuite.addTest(TestByteOffset("test_byte_offset"))
 #     testSuite.addTest(TestAlgebra("test_compact"))
     return testSuite

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -76,9 +76,6 @@ class TestByteOffset(unittest.TestCase):
                 raise unittest.SkipTest("Byte-offset decompression is known to be buggy on MacOS-CPU")
             else:
                 raise err
-        except Exception as err:
-            logger.warning(err)
-            logger.warning(type(err))
 
         t0 = time.time()
         res_cy = fabio.compression.decByteOffset(raw)

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Byte-offset decompression in OpenCL
+#             https://github.com/silx-kit/silx
+#
+#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test suite for byte-offset decompression 
+"""
+
+from __future__ import division, print_function
+
+__authors__ = ["Jérôme Kieffer"]
+__contact__ = "jerome.kieffer@esrf.eu"
+__license__ = "MIT"
+__copyright__ = "2013 European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "13/10/2017"
+
+import os
+import time
+import logging
+import numpy
+
+import unittest
+
+
+def suite():
+    testSuite = unittest.TestSuite()
+#     testSuite.addTest(TestAlgebra("test_combine"))
+#     testSuite.addTest(TestAlgebra("test_compact"))
+    return testSuite

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -57,6 +57,7 @@ class TestByteOffset(unittest.TestCase):
         """
         tests the byte offset decompression on GPU
         """
+        import pyopencl
         shape = (2713, 2719)
         size = numpy.prod(shape)
         nexcept = 2729
@@ -69,12 +70,15 @@ class TestByteOffset(unittest.TestCase):
         raw = fabio.compression.compByteOffset(ref)
         try:
             bo = byte_offset.ByteOffset(len(raw), size, profile=True)
-        except RuntimeError as err:
+        except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             if sys.platform == "darwin":
                 raise unittest.SkipTest("Byte-offset decompression is known to be buggy on MacOS-CPU")
             else:
                 raise err
+        except Exception as err:
+            logger.warning(err)
+            logger.warning(type(err))
 
         t0 = time.time()
         res_cy = fabio.compression.decByteOffset(raw)
@@ -96,6 +100,7 @@ class TestByteOffset(unittest.TestCase):
         tests the byte offset decompression on GPU, many images to ensure there 
         is not leaking in memory 
         """
+        import pyopencl
         shape = (991, 997)
         size = numpy.prod(shape)
         nexcept = 2729
@@ -104,7 +109,7 @@ class TestByteOffset(unittest.TestCase):
         raw = fabio.compression.compByteOffset(ref)
         try:
             bo = byte_offset.ByteOffset(len(raw), size, profile=False)
-        except RuntimeError as err:
+        except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             if sys.platform == "darwin":
                 raise unittest.SkipTest("Byte-offset decompression is known to be buggy on MacOS-CPU")

--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "2012-2017 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "05/10/2017"
+__date__ = "16/10/2017"
 __status__ = "stable"
 __all__ = ["ocl", "pyopencl", "mf", "release_cl_buffers", "allocate_cl_buffers",
            "measure_workgroup_size", "kernel_workgroup_size"]
@@ -399,8 +399,8 @@ class OpenCL(object):
         # Nothing found
         return None
 
-    def create_context(self, devicetype="ALL", useFp64=False, platformid=None,
-                       deviceid=None, cached=True):
+    def create_context(self, devicetype="ALL", memory=None, useFp64=False,
+                       platformid=None, deviceid=None, cached=True):
         """
         Choose a device and initiate a context.
 
@@ -410,6 +410,7 @@ class OpenCL(object):
         E.g.: If Nvidia driver is installed, GPU will succeed but CPU will fail.
               The AMD SDK kit is required for CPU via OpenCL.
         :param devicetype: string in ["cpu","gpu", "all", "acc"]
+        :param memory: select device with at least this amount of memory
         :param useFp64: boolean specifying if double precision will be used
         :param platformid: integer
         :param deviceid: integer
@@ -425,9 +426,10 @@ class OpenCL(object):
             platformid, deviceid = pyopencl_ctx
         else:
             if useFp64:
-                ids = ocl.select_device(type=devicetype, extensions=["cl_khr_int64_base_atomics"])
+                ids = ocl.select_device(type=devicetype, memory=memory,
+                                        extensions=["cl_khr_int64_base_atomics"])
             else:
-                ids = ocl.select_device(dtype=devicetype)
+                ids = ocl.select_device(dtype=devicetype, memory=memory)
             if ids:
                 platformid, deviceid = ids
         if (platformid is not None) and (deviceid is not None):

--- a/silx/opencl/setup.py
+++ b/silx/opencl/setup.py
@@ -27,7 +27,7 @@ __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __authors__ = ["J. Kieffer"]
-__date__ = "16/08/2017"
+__date__ = "16/10/2017"
 
 import os.path
 from numpy.distutils.misc_util import Configuration
@@ -38,6 +38,7 @@ def configuration(parent_package='', top_path=None):
     path = os.path.dirname(os.path.abspath(__file__))
     if os.path.exists(os.path.join(path, 'sift')):
         config.add_subpackage('sift')
+    config.add_subpackage('codec')
     config.add_subpackage('test')
     return config
 

--- a/silx/opencl/test/__init__.py
+++ b/silx/opencl/test/__init__.py
@@ -24,7 +24,7 @@
 
 __authors__ = ["J. Kieffer"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "17/10/2017"
 
 import os
 import unittest
@@ -34,6 +34,8 @@ from . import test_backprojection
 from . import test_projection
 from . import test_linalg
 from . import test_array_utils
+from ..codec import test as test_codec
+
 
 def suite():
     test_suite = unittest.TestSuite()
@@ -43,7 +45,7 @@ def suite():
     test_suite.addTests(test_projection.suite())
     test_suite.addTests(test_linalg.suite())
     test_suite.addTests(test_array_utils.suite())
-
+    test_suite.addTests(test_codec.suite())
     # Allow to remove sift from the project
     test_base_dir = os.path.dirname(__file__)
     sift_dir = os.path.join(test_base_dir, "..", "sift")

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -74,7 +74,6 @@ kernel void mark_exceptions(global char* raw, int size, global int* mask,  globa
 kernel void treat_exceptions(global char* raw,
                              int size,
                              global int* mask,
-                             global int* cnt,
                              global int* exc,
                              global int* values,
                              global int* delta)
@@ -178,3 +177,29 @@ kernel void copy_values(global char* raw,
         }
     }
 }
+
+//Simple memset kernel for char arrays
+kernel void fill_char_mem(global char* ary,
+                          int size
+                          char pattern,
+                          int start_at)
+{
+    int gid = get_global_id(0);
+    if (gid >= start_at) && (gid < size))
+    {
+        ary[gid] = pattern;
+    }
+}
+
+//Simple memset kernel for int arrays
+kernel void fill_int_mem(global int* ary,
+                         int size
+                         int pattern)
+{
+    int gid = get_global_id(0);
+    if (gid < size)
+    {
+        ary[gid] = pattern;
+    }
+}
+

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -29,17 +29,17 @@
  */
 
 /* To decompress CBF byte-offset compressed in parallel on GPU one needs to:
+ * - Set all values in mask and exception counter to zero.
  * - Mark regions with exceptions and set values without exception.
- *   This is a map kernel, the workgroup size does not matter.
  *   This generates the values (zeros for exceptions), the exception mask,
- *   counts the number of region and provides a start position for
- *   each of them.
+ *   counts the number of exception region and provides a start position for
+ *   each exception.
  * - Treat exceptions. For this, one thread in a workgoup treats a complete
  *   masked region in a serial fashion. All regions are treated in parallel.
  *   Values written at this stage are marked in the mask with -1.
  * - Double scan: inclusive cum sum for values, exclusive cum sum to generate
  *   indices in output array. Values with mask = 1 are considered as 0.
- * - Compact and copy output by removing duplicated values in exceptions
+ * - Compact and copy output by removing duplicated values in exceptions.
  */
 
 kernel void mark_exceptions(global char* raw,

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -62,19 +62,17 @@ kernel void mark_exceptions(global char* raw,
             position = atomic_inc(cnt);
             exc[position] = gid;
             maxi = size - 1;
+            mask[gid] = 1;
+            mask[min(maxi, gid+1)] = 1;
+		    mask[min(maxi, gid+2)] = 1;
+
             if (((int) raw[min(gid+1, maxi)] == 0) &&
                 ((int) raw[min(gid+2, maxi)] == -128))
             {
-                maxi = 7;
-            }
-            else
-            {
-                maxi = 3;
-            }
-            maxi = min(size, gid+maxi);
-            for (int i=gid; i<maxi; i++)
-            {// atomic does not matter as we are not actually counting
-                mask[i]=1;
+                mask[min(maxi, gid+3)] = 1;
+    		    mask[min(maxi, gid+4)] = 1;
+                mask[min(maxi, gid+5)] = 1;
+    		    mask[min(maxi, gid+6)] = 1;
             }
         }
         else

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -64,15 +64,15 @@ kernel void mark_exceptions(global char* raw,
             maxi = size - 1;
             mask[gid] = 1;
             mask[min(maxi, gid+1)] = 1;
-		    mask[min(maxi, gid+2)] = 1;
+            mask[min(maxi, gid+2)] = 1;
 
             if (((int) raw[min(gid+1, maxi)] == 0) &&
                 ((int) raw[min(gid+2, maxi)] == -128))
             {
                 mask[min(maxi, gid+3)] = 1;
-    		    mask[min(maxi, gid+4)] = 1;
+                mask[min(maxi, gid+4)] = 1;
                 mask[min(maxi, gid+5)] = 1;
-    		    mask[min(maxi, gid+6)] = 1;
+                mask[min(maxi, gid+6)] = 1;
             }
         }
         else
@@ -97,12 +97,7 @@ kernel void treat_exceptions(global char* raw,  //raw compressed stream
 {
     int gid = get_global_id(0);
     int inp_pos = exc[gid];
-    if ((inp_pos>0) && ((int)mask[inp_pos - 1] != 0))
-    { // This is actually not another exception, remove from list.
-      // Those data will be treated by another workgroup.
-        exc[gid] = -1;
-    }
-    else
+    if ((inp_pos<=0) || ((int)mask[inp_pos - 1] == 0))
     {
         int value, is_masked, next_value, inc;
         is_masked = (mask[inp_pos] != 0);
@@ -113,8 +108,6 @@ kernel void treat_exceptions(global char* raw,  //raw compressed stream
             { // this correspond to 16 bits exception
                 uchar low_byte = raw[inp_pos+1];
                 char high_byte = raw[inp_pos+2] ;
-                mask[inp_pos + 1] = 1;
-                mask[inp_pos + 2] = 1;
                 next_value = high_byte<<8 | low_byte;
                 if (next_value == -32768)
                 { // this correspond to 32 bits exception
@@ -124,11 +117,6 @@ kernel void treat_exceptions(global char* raw,  //raw compressed stream
                     char high_byte4 = raw[inp_pos+6] ;
                     value = high_byte4<<24 | low_byte3<<16 | low_byte2<<8 | low_byte1;
                     inc = 7;
-                    mask[inp_pos + 3] = 1;
-                    mask[inp_pos + 4] = 1;
-                    mask[inp_pos + 5] = 1;
-                    mask[inp_pos + 6] = 1;
-                    
                 }
                 else
                 {
@@ -144,33 +132,6 @@ kernel void treat_exceptions(global char* raw,  //raw compressed stream
             mask[inp_pos] = -1; // mark the processed data as valid in the mask
             inp_pos += inc;
             is_masked = (mask[inp_pos] != 0);
-        }
-    }
-}
-
-// copy the values of the non-exceptions elements based on the mask.
-// Set the value of the mask to the current position  or -2
-kernel void treat_simple(global char* raw,
-                         int size,
-                         global int* mask,
-                         global int* values)
-{
-    int gid = get_global_id(0);
-    if (gid < size)
-    {
-        if (mask[gid] > 0)
-        { // convert the masked position from a positive value to a negative one
-            mask[gid] = -2;
-            values[gid] = 0; //this prevents a full memset of the array
-        }
-        else if (mask[gid] == -1)
-        { // this is an exception and has already been treated.
-            mask[gid] = gid;
-        }
-        else
-        { // normal case
-            values[gid] = raw[gid];
-            mask[gid] = gid;
         }
     }
 }

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -29,16 +29,17 @@
  */
 
 /* To decompress CBF byte-offset compressed in parallel on GPU one needs to:
- * - Mark regions with exceptions. This is a map kernel, the workgroup size does
- *   not matter. This generates the mask, counts the number of region and provides
- *   a start position for each of them.
- * - treat exceptions. For this, one thread in a workgoup treats a complete masked
- *   region in a serial fashion. All regions are treated in parallel.
- * - Normal pixels are marked having a size of 1 (TODO: do this with previous kernel + fill!)
- * - Valid pixels are copied (compact for zeros in delta)
- * - Input position is calculated from a cum_sum
- * - proper pixel values are copied
- * - Finally a cum-sum is performed to retrieve the decompressed data
+ * - Mark regions with exceptions and set values without exception.
+ *   This is a map kernel, the workgroup size does not matter.
+ *   This generates the values (zeros for exceptions), the exception mask,
+ *   counts the number of region and provides a start position for
+ *   each of them.
+ * - Treat exceptions. For this, one thread in a workgoup treats a complete
+ *   masked region in a serial fashion. All regions are treated in parallel.
+ *   Values written at this stage are marked in the mask with -1.
+ * - Double scan: inclusive cum sum for values, exclusive cum sum to generate
+ *   indices in output array. Values with mask = 1 are considered as 0.
+ * - Compact and copy output by removing duplicated values in exceptions
  */
 
 kernel void mark_exceptions(global char* raw,

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -189,7 +189,7 @@ kernel void copy_result_int(global int* values,
     if (gid < in_size)
     {
         int current = max(indexes[gid], 0),
-               next = (gid >= (in_size - 1)) ? in_size : indexes[gid + 1];
+               next = (gid >= (in_size - 1)) ? in_size + 1 : indexes[gid + 1];
         //we keep always the last element
         if ((current <= out_size) && (current < next))
         {

--- a/silx/resources/opencl/codec/byte_offset.cl
+++ b/silx/resources/opencl/codec/byte_offset.cl
@@ -1,0 +1,180 @@
+/*
+ *   Project: SILX: A data analysis tool-kit
+ *
+ *   Copyright (C) 2017 European Synchrotron Radiation Facility
+ *                           Grenoble, France
+ *
+ *   Principal authors: J. Kieffer (kieffer@esrf.fr)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* To decompress CBF byte-offset compressed in parallel on GPU one needs to:
+ * - Mark regions with exceptions. This is a map kernel, the workgroup size does
+ *   not matter. This generates the mask, counts the number of region and provides
+ *   a start position for each of them.
+ * - treat exceptions. For this, one thread in a workgoup treats a complete masked
+ *   region in a serial fashion. All regions are treated in parallel.
+ * - Normal pixels are marked having a size of 1 (TODO: do this with previous kernel + fill!)
+ * - Valid pixels are copied (compact for zeros in delta)
+ * - Input position is calculated from a cum_sum
+ * - proper pixel values are copied
+ * - Finally a cum-sum is performed to retrieve the decompressed data
+ */
+
+kernel void mark_exceptions(global char* raw, int size, global int* mask,  global int* cnt, global int* exc)
+{
+    int ws, gid, lid;
+    ws = get_local_size(0);
+    lid = get_local_id(0);
+    gid = get_global_id(0);
+    if (gid<size)
+    {
+        int value, position;
+        value = raw[gid];
+        if (value == -128)
+        {
+            position = atomic_inc(cnt);
+            exc[position] = gid;
+            atomic_inc(&mask[gid]);
+            atomic_inc(&mask[gid+1]);
+            atomic_inc(&mask[gid+2]);
+            if (((int) raw[gid+1] == 0) && ((int) raw[gid+2] == -128))
+            {
+                atomic_inc(&mask[gid+3]);
+                atomic_inc(&mask[gid+4]);
+                atomic_inc(&mask[gid+5]);
+                atomic_inc(&mask[gid+6]);
+            }
+
+        }
+
+    }
+}
+//run with WG=1, as may as exceptions
+kernel void treat_exceptions(global char* raw,
+                             int size,
+                             global int* mask,
+                             global int* cnt,
+                             global int* exc,
+                             global int* values,
+                             global int* delta)
+{
+    int gid = get_global_id(0);
+    int position = exc[gid];
+    if ((position>0) && ((int)mask[position-1] !=0))
+    { // this is actually not another exception, remove from list
+        exc[gid] = -1;
+    }
+    else
+    {
+        int inp_pos, out_pos, value, is_masked, next_value, inc;
+        inp_pos = position;
+        out_pos = position;
+        is_masked = mask[inp_pos];
+        while ((is_masked) && (inp_pos<size) && (out_pos<size))
+        {
+            value = (int) raw[inp_pos];
+            if (value == -128)
+            {
+                uchar low_byte = raw[inp_pos+1];
+                char high_byte = raw[inp_pos+2] ;
+
+                next_value = high_byte<<8 | low_byte;
+                if (next_value == -32768)
+                {
+                    uchar low_byte1 = raw[inp_pos+3],
+                          low_byte2 = raw[inp_pos+4],
+                          low_byte3 = raw[inp_pos+5];
+                    char high_byte4 = raw[inp_pos+6] ;
+                    value = high_byte4<<24 | low_byte3<<16 | low_byte2<<8 | low_byte1;
+                    inc = 7;
+                }
+                else
+                {
+                    value = next_value;
+                    inc = 3;
+                }
+            }
+            else
+            {
+                inc = 1;
+            }
+            values[inp_pos] = value;
+            delta[inp_pos] = inc;
+            inp_pos += inc;
+            out_pos += 1 ;
+            is_masked = mask[inp_pos];
+        }
+    }
+}
+
+kernel void calc_size(int size,
+                      global int* mask,
+                      global int* delta)
+{
+    int gid = get_global_id(0);
+    if (gid < size)
+    {
+        int is_masked;
+        is_masked = mask[gid];
+        if (!is_masked)
+        {
+            delta[gid] = 1;
+        }
+    }
+}
+kernel void copy_values(global char* raw,
+                        int size,
+                        int datasize,
+                        global int* values,
+                        global int* exception_values,
+                        global int* positions,
+                        global int* delta)
+{
+    int gid = get_global_id(0);
+    int in_pos, value_size;
+    if (gid < datasize)
+    {
+        if (gid == 0)
+        {
+            in_pos = 0;
+        }
+        else
+        {
+            in_pos = positions[gid-1];
+        }
+
+        if (in_pos < size)
+        {
+            value_size = delta[in_pos];
+            if (value_size == 1)
+            {
+                values[gid] = (int) raw[in_pos];
+            }
+            else if (value_size >1)
+            {
+                values[gid] = exception_values[in_pos];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides:
- An additional workaround for mpl2.1.0 when the limits of an axis are both <=0. In this case it redraw the plot with positive bounds before changing to log scale. This adds some flicker in this case but avoids the plot to freeze.
- A split of `resetZoom` to add a `_forceResetZoom` method that does not consider axes autoscale.